### PR TITLE
Fix: undefined 'epochs' variable in exp_elas.py

### DIFF
--- a/PDE-Solving-StandardBenchmark/exp_elas.py
+++ b/PDE-Solving-StandardBenchmark/exp_elas.py
@@ -99,7 +99,7 @@ def main():
     print(model)
     count_parameters(model)
     
-    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)
     
     myloss = TestLoss(size_average=False)
 


### PR DESCRIPTION
This PR fixes a bug in `PDE-Solving-StandardBenchmark/exp_elas.py`, where `epochs` was referenced directly without being defined.

Replaced:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)

With:
    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=args.epochs)

The code now correctly uses the argument parser value. The bug previously prevented training from running correctly.

Tested with:
- Ubuntu 20.04
- Python 3.8
- CUDA 12.x
- PyTorch 1.10.1 + cu113 (for full compatibility with the existing repo)
- NVIDIA RTX 4090